### PR TITLE
Use proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/react": "^16.14.6",
         "@types/react-dom": "^16.9.12",
         "@types/react-router-dom": "^5.1.7",
-        "@vulcan-fydp/schema": "github:vulcan-fydp/schema#semver:^0.0.22",
+        "@vulcan-fydp/schema": "github:vulcan-fydp/schema#semver:^0.0.27",
         "framer-motion": "^4.1.11",
         "graphql": "^15.5.0",
         "react": "^17.0.2",
@@ -42,6 +42,7 @@
         "@graphql-codegen/typescript-react-apollo": "2.2.4",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-graphql": "^4.0.0",
+        "http-proxy-middleware": "^0.19.1",
         "prettier": "^2.2.1"
       }
     },
@@ -5714,8 +5715,8 @@
       }
     },
     "node_modules/@vulcan-fydp/schema": {
-      "version": "0.0.22",
-      "resolved": "git+ssh://git@github.com/vulcan-fydp/schema.git#f0f3b8e4e66d24fbd727c9cce63058aea2dc3204",
+      "version": "0.0.27",
+      "resolved": "git+ssh://git@github.com/vulcan-fydp/schema.git#ce5436198a26fd41b778ffbd6823e33e9d302c71",
       "license": "ISC"
     },
     "node_modules/@webassemblyjs/ast": {
@@ -31059,8 +31060,8 @@
       }
     },
     "@vulcan-fydp/schema": {
-      "version": "git+ssh://git@github.com/vulcan-fydp/schema.git#f0f3b8e4e66d24fbd727c9cce63058aea2dc3204",
-      "from": "@vulcan-fydp/schema@github:vulcan-fydp/schema#semver:^0.0.22"
+      "version": "git+ssh://git@github.com/vulcan-fydp/schema.git#ce5436198a26fd41b778ffbd6823e33e9d302c71",
+      "from": "@vulcan-fydp/schema@github:vulcan-fydp/schema#semver:^0.0.27"
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/react": "^16.14.6",
     "@types/react-dom": "^16.9.12",
     "@types/react-router-dom": "^5.1.7",
-    "@vulcan-fydp/schema": "github:vulcan-fydp/schema#semver:^0.0.22",
+    "@vulcan-fydp/schema": "github:vulcan-fydp/schema#semver:^0.0.27",
     "framer-motion": "^4.1.11",
     "graphql": "^15.5.0",
     "react": "^17.0.2",
@@ -60,6 +60,7 @@
     "@graphql-codegen/typescript-react-apollo": "2.2.4",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-graphql": "^4.0.0",
+    "http-proxy-middleware": "^0.19.1",
     "prettier": "^2.2.1"
   }
 }

--- a/src/apollo.ts
+++ b/src/apollo.ts
@@ -1,20 +1,8 @@
-import {
-  ApolloClient,
-  createHttpLink,
-  InMemoryCache,
-  split,
-} from "@apollo/client";
+import { ApolloClient, createHttpLink, InMemoryCache } from "@apollo/client";
 
-const link = split(
-  (operation) => operation.getContext().target === "backend",
-  createHttpLink({
-    uri: "http://localhost:4000/graphql",
-    credentials: "include",
-  }),
-  createHttpLink({
-    uri: "http://localhost:5000/graphql",
-  })
-);
+const link = createHttpLink({
+  uri: (operation) => `/${operation.getContext().target}/graphql`,
+});
 
 export const apolloClient = new ApolloClient({
   link,

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,21 @@
+const createProxyMiddleware = require('http-proxy-middleware');
+
+module.exports = function(app) {
+  app.use(
+    '/backend',
+    createProxyMiddleware({
+      target: 'http://localhost:4000',
+      changeOrigin: true,
+      pathRewrite: path => path.replace('/backend', '')
+    })
+  );
+
+  app.use(
+    '/relay',
+    createProxyMiddleware({ 
+      target: 'http://localhost:8443', 
+      changeOrigin: true,
+      pathRewrite: path => path.replace('/relay', '')
+    })
+  );
+};


### PR DESCRIPTION
This allows the client to make all requests to `localhost:3000` and they backend and relay requests will get proxied through to other ports. So far has been tested with the backend