### PR TITLE
Fix data producer bug and refactor stream to expose send controller input call

### DIFF
--- a/src/pages/room/Room/streamTab.tsx
+++ b/src/pages/room/Room/streamTab.tsx
@@ -116,6 +116,7 @@ const ExampleControllerInputSender: React.FC<ExampleControllerInputProps> = ({
         onClick={() => {
           if (dataProducerRef.current?.closed) {
             console.log("Data Producer is closed, unable to send inputs");
+            return;
           }
           console.log("Sending input: ", sendData);
           // Call the line below to send controller inputs!


### PR DESCRIPTION
- I originally forgot to call `success` which prevented the data producer from initializing
- Refactored all the relay connection logic out to the `StreamTab` parent component in order to pass the data producer to the `ExampleControllerInputSender` child