### PR TITLE
Codegen docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "web",
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
@@ -46,10 +47,17 @@
         "@graphql-codegen/typescript": "^2.4.2",
         "@graphql-codegen/typescript-operations": "^2.2.2",
         "@graphql-codegen/typescript-react-apollo": "^3.2.2",
+        "@types/glob": "^7.2.0",
+        "@types/lodash.kebabcase": "^4.1.6",
+        "@types/rimraf": "^3.0.2",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-graphql": "^4.0.0",
+        "glob": "^7.2.0",
         "http-proxy-middleware": "^2.0.1",
-        "prettier": "^2.5.1"
+        "lodash.kebabcase": "^4.1.1",
+        "prettier": "^2.5.1",
+        "rimraf": "^3.0.2",
+        "ts-node": "^10.4.0"
       }
     },
     "node_modules/@apollo/client": {
@@ -3025,6 +3033,27 @@
         "react": ">=16.8.6"
       }
     },
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "devOptional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "devOptional": true,
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -3200,6 +3229,32 @@
       },
       "peerDependencies": {
         "cosmiconfig": ">=6"
+      }
+    },
+    "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader/node_modules/ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "dependencies": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -6526,6 +6581,30 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "devOptional": true
+    },
     "node_modules/@types/aria-query": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz",
@@ -6654,6 +6733,16 @@
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "node_modules/@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -6890,6 +6979,15 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
       "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
     },
+    "node_modules/@types/lodash.kebabcase": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.kebabcase/-/lodash.kebabcase-4.1.6.tgz",
+      "integrity": "sha512-+RAD9pCAa8kuVyCYTeDNiwBXwD/0u0p+hos3NSqD+tXTjJextbfF3farfYB+ssAKgEssoewXEtBsfwBpsI7gsA==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/lodash.mergewith": {
       "version": "4.6.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.6.tgz",
@@ -6902,6 +7000,12 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+    },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "17.0.5",
@@ -6987,6 +7091,16 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+    },
+    "node_modules/@types/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.1",
@@ -12149,9 +12263,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -16204,6 +16318,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+      "dev": true
+    },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
       "dev": true
     },
     "node_modules/lodash.memoize": {
@@ -21684,29 +21804,53 @@
       "dev": true
     },
     "node_modules/ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
       "devOptional": true,
       "dependencies": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
         "yn": "3.1.1"
       },
       "bin": {
         "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
         "ts-node-script": "dist/bin-script.js",
         "ts-node-transpile-only": "dist/bin-transpile.js",
         "ts-script": "dist/bin-script-deprecated.js"
       },
-      "engines": {
-        "node": ">=10.0.0"
-      },
       "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
         "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -25194,6 +25338,21 @@
         "@chakra-ui/utils": "1.9.1"
       }
     },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "devOptional": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "devOptional": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
     "@csstools/normalize.css": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -25328,6 +25487,22 @@
         "make-error": "^1",
         "ts-node": "^9",
         "tslib": "^2"
+      },
+      "dependencies": {
+        "ts-node": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+          "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+          "dev": true,
+          "requires": {
+            "arg": "^4.1.0",
+            "create-require": "^1.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "source-map-support": "^0.5.17",
+            "yn": "3.1.1"
+          }
+        }
       }
     },
     "@eslint/eslintrc": {
@@ -27845,6 +28020,30 @@
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="
     },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "devOptional": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "devOptional": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "devOptional": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "devOptional": true
+    },
     "@types/aria-query": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz",
@@ -27973,6 +28172,16 @@
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
       }
     },
     "@types/graceful-fs": {
@@ -28171,6 +28380,15 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
       "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
     },
+    "@types/lodash.kebabcase": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.kebabcase/-/lodash.kebabcase-4.1.6.tgz",
+      "integrity": "sha512-+RAD9pCAa8kuVyCYTeDNiwBXwD/0u0p+hos3NSqD+tXTjJextbfF3farfYB+ssAKgEssoewXEtBsfwBpsI7gsA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/lodash.mergewith": {
       "version": "4.6.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.6.tgz",
@@ -28183,6 +28401,12 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+    },
+    "@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
     },
     "@types/node": {
       "version": "17.0.5",
@@ -28268,6 +28492,16 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+    },
+    "@types/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "@types/scheduler": {
       "version": "0.16.1",
@@ -32177,9 +32411,9 @@
       }
     },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -35184,6 +35418,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+      "dev": true
+    },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
       "dev": true
     },
     "lodash.memoize": {
@@ -39078,17 +39318,31 @@
       "dev": true
     },
     "ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
       "devOptional": true,
       "requires": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
         "yn": "3.1.1"
+      },
+      "dependencies": {
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "devOptional": true
+        }
       }
     },
     "tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -66,9 +66,16 @@
     "@graphql-codegen/typescript": "^2.4.2",
     "@graphql-codegen/typescript-operations": "^2.2.2",
     "@graphql-codegen/typescript-react-apollo": "^3.2.2",
+    "@types/glob": "^7.2.0",
+    "@types/lodash.kebabcase": "^4.1.6",
+    "@types/rimraf": "^3.0.2",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-graphql": "^4.0.0",
+    "glob": "^7.2.0",
     "http-proxy-middleware": "^2.0.1",
-    "prettier": "^2.5.1"
+    "lodash.kebabcase": "^4.1.1",
+    "prettier": "^2.5.1",
+    "rimraf": "^3.0.2",
+    "ts-node": "^10.4.0"
   }
 }

--- a/scripts/gen-docs.ts
+++ b/scripts/gen-docs.ts
@@ -1,0 +1,165 @@
+import glob from "glob";
+import fs from "fs";
+import kebabCase from "lodash.kebabcase";
+import rimraf from "rimraf";
+
+const DEFINE_DOC =
+  /defineDoc\(\{\s*title:\s*"([\w ]+)",\s*breadcrumbPath:\s*"([\w ]+)",\s*content:\s*<>(.*)<\/>,\s*}\)/ms;
+
+const ALPHANUMERIC_CHAR = /^[a-zA-Z0-9]/;
+
+interface DocResource {
+  title: string;
+  definitionPath: string;
+  content: string;
+  breadcrumbPath: string;
+  route: string;
+
+  generatedSrc: string;
+  generatedComponentName: string;
+  generatedFilePath: string;
+}
+
+function getRoute({ definitionPath }: DocResource): string {
+  const parts = definitionPath.split("/");
+  return (
+    parts.slice(3, -1).join("/") +
+    "/" +
+    kebabCase(parts[parts.length - 1].replace(".doc.tsx", ""))
+  );
+}
+
+function getGeneratedComponentName({ title }: DocResource): string {
+  return (
+    "Doc" +
+    title
+      .split("")
+      .map((ch, i, arr) => {
+        if (
+          i > 0 &&
+          !ALPHANUMERIC_CHAR.test(arr[i - 1]) &&
+          ALPHANUMERIC_CHAR.test(arr[i])
+        ) {
+          return ch.toUpperCase();
+        }
+
+        return ch;
+      })
+      .map((ch) => (ALPHANUMERIC_CHAR.test(ch) ? ch : ""))
+      .join("")
+  );
+}
+
+function getGeneratedSrc({
+  content,
+  generatedComponentName,
+  title,
+}: DocResource) {
+  return `
+/* eslint-disable */
+import { DocParagraph } from "pages/docs/components";
+import { DocPage } from "pages/docs/components/DocPage";
+
+export default () => <DocPage title="${title}">${content}</DocPage>;
+`.trimStart();
+}
+
+function getGeneratedFilePath({ generatedComponentName }: DocResource) {
+  return `src/pages/docs/generated/${generatedComponentName}.generated.tsx`;
+}
+
+async function generateDocResources(
+  fileName: string
+): Promise<DocResource | undefined> {
+  const fileContent = await fs.promises.readFile(fileName, {
+    encoding: "utf-8",
+  });
+
+  const match = fileContent.match(DEFINE_DOC);
+
+  if (match === null) {
+    console.error(`Failed to parse file ${fileName}`);
+    return;
+  }
+
+  const [_, title, breadcrumbPath, content] = match;
+
+  const resource = {
+    title,
+    breadcrumbPath,
+    content,
+    definitionPath: fileName,
+  } as DocResource;
+
+  resource.route = getRoute(resource);
+  resource.generatedComponentName = getGeneratedComponentName(resource);
+  resource.generatedSrc = getGeneratedSrc(resource);
+  resource.generatedFilePath = getGeneratedFilePath(resource);
+
+  return resource;
+}
+
+async function saveDocResource(resource: DocResource) {
+  await fs.promises.writeFile(
+    resource.generatedFilePath,
+    resource.generatedSrc
+  );
+}
+
+async function generateRouterFile(resources: DocResource[]) {
+  const content = `
+import { Route, Switch } from "react-router";
+import React from "react";
+${resources
+  .map(
+    (r) =>
+      `const ${r.generatedComponentName} = React.lazy(() => import("./${r.generatedComponentName}.generated"));`
+  )
+  .join("\n")}
+
+function createLazyDoc(
+  Component: React.LazyExoticComponent<() => JSX.Element>
+) {
+  return () => (
+    <React.Suspense fallback={null}>
+      <Component />
+    </React.Suspense>
+  );
+}
+
+export const DocsRouter = () => {
+  return (
+    <Switch>
+      ${resources
+        .map(
+          (r) =>
+            `<Route exact path="/${r.route}" render={createLazyDoc(${r.generatedComponentName})} />`
+        )
+        .join("\n      ")}
+    </Switch>
+  );
+};
+`.trimStart();
+
+  await fs.promises.writeFile(
+    "src/pages/docs/generated/DocsRouter.tsx",
+    content
+  );
+}
+
+async function main() {
+  rimraf.sync(__dirname + "src/pages/docs/generated");
+  const docFiles = glob.sync("src/pages/docs/**/*.doc.tsx");
+  const docResources = await Promise.all(docFiles.map(generateDocResources));
+
+  if (docResources.some((r) => !r)) {
+    console.log("Stopping because of errors");
+    return;
+  }
+
+  await Promise.all((docResources as DocResource[]).map(saveDocResource));
+
+  await generateRouterFile(docResources as DocResource[]);
+}
+
+main();

--- a/src/pages/docs/components/defineDoc.tsx
+++ b/src/pages/docs/components/defineDoc.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export function defineDoc(_definition: {
+  title: string;
+  breadcrumbPath: string;
+  content: React.ReactNode;
+}): void {}

--- a/src/pages/docs/docs/Vulcast.doc.tsx
+++ b/src/pages/docs/docs/Vulcast.doc.tsx
@@ -1,0 +1,7 @@
+import { defineDoc } from "../components/defineDoc";
+
+defineDoc({
+  title: "Vulcast",
+  breadcrumbPath: "Vulcast",
+  content: <>Hello</>,
+});

--- a/src/pages/docs/docs/vulcast/CreatingAVulcast.doc.tsx
+++ b/src/pages/docs/docs/vulcast/CreatingAVulcast.doc.tsx
@@ -1,0 +1,7 @@
+import { defineDoc } from "pages/docs/components/defineDoc";
+
+defineDoc({
+  title: "Creating A Vulcast",
+  breadcrumbPath: "Creating A Vulcast",
+  content: <>This is what you need to buy</>,
+});

--- a/src/pages/docs/generated/.gitignore
+++ b/src/pages/docs/generated/.gitignore
@@ -1,0 +1,1 @@
+*.generated.tsx

--- a/src/pages/docs/generated/DocsRouter.tsx
+++ b/src/pages/docs/generated/DocsRouter.tsx
@@ -1,0 +1,23 @@
+import { Route, Switch } from "react-router";
+import React from "react";
+const DocVulcast = React.lazy(() => import("./DocVulcast.generated"));
+const DocCreatingAVulcast = React.lazy(() => import("./DocCreatingAVulcast.generated"));
+
+function createLazyDoc(
+  Component: React.LazyExoticComponent<() => JSX.Element>
+) {
+  return () => (
+    <React.Suspense fallback={null}>
+      <Component />
+    </React.Suspense>
+  );
+}
+
+export const DocsRouter = () => {
+  return (
+    <Switch>
+      <Route exact path="/docs/vulcast" render={createLazyDoc(DocVulcast)} />
+      <Route exact path="/docs/vulcast/creating-a-vulcast" render={createLazyDoc(DocCreatingAVulcast)} />
+    </Switch>
+  );
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,7 @@ import { Home } from "./Home";
 import { LoginRouter } from "pages/login";
 import { RoomRouter } from "./room";
 import { ControllersRouter } from "./controllers";
-import { DocsRouter, DocsRoutes } from "./docs";
+import { DocsRouter } from "./docs/generated/DocsRouter";
 import { AccountPage } from "./account";
 
 export const Pages = () => (
@@ -16,7 +16,7 @@ export const Pages = () => (
     <Route path="/controllers" render={() => <ControllersRouter />} />
     <Route exact path="/account" render={() => <AccountPage />} />
 
-    <Route path={DocsRoutes.base()} render={() => <DocsRouter />} />
+    <Route path={"/docs"} render={() => <DocsRouter />} />
 
     <Route render={() => null} />
   </Switch>


### PR DESCRIPTION
## Why do we need to codegen docs?
1. We can remove the manual part of integrating a doc into the application. By automating this we can easily apply optimizations through code-splitting to reduce bundle sizes and improve performance
2. If we ever want to offer search functionality we will need to statically parse the docs, this is the first step of that process
3. We can simplify the writing process for non-web devs
4. Michal must overengineer everything

## Are there other solutions?
The other solution that we could do is to add a step to webpack to automatically compile these files at build time. In order to do this we would have to eject from cra and webpack is hard
