### PR TITLE
Upgrade to react router 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "web",
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
@@ -21,7 +22,6 @@
         "@types/node": "^17.0.5",
         "@types/react": "^16.14.6",
         "@types/react-dom": "^17.0.11",
-        "@types/react-router-dom": "^5.1.7",
         "@vulcan-fydp/schema": "github:vulcan-fydp/schema#semver:^0.0.37",
         "controller-input": "^0.3.0",
         "framer-motion": "^5.6.0",
@@ -32,11 +32,11 @@
         "react-dom": "^17.0.2",
         "react-hook-form": "^7.22.5",
         "react-icons": "^4.3.1",
-        "react-router-dom": "^5.2.0",
+        "react-router": "^6.2.1",
+        "react-router-dom": "^6.2.1",
         "react-scripts": "5.0.0",
         "subscriptions-transport-ws": "^0.9.19",
         "typescript": "^4.5.4",
-        "use-query-params": "^1.2.3",
         "web-vitals": "^2.1.2"
       },
       "devDependencies": {
@@ -6651,11 +6651,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/history": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",
-      "integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA=="
-    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -6941,25 +6936,6 @@
       "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
       "dependencies": {
         "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-router": {
-      "version": "5.1.14",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.14.tgz",
-      "integrity": "sha512-LAJpqYUaCTMT2anZheoidiIymt8MuX286zoVFPM3DVb23aQBH0mAkFvzpd4LKqiolV8bBtZWT5Qp7hClCNDENw==",
-      "dependencies": {
-        "@types/history": "*",
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-router-dom": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.7.tgz",
-      "integrity": "sha512-D5mHD6TbdV/DNHYsnwBTv+y73ei+mMjrkGrla86HthE4/PVvL1J94Bu3qABU+COXzpL23T1EZapVVpwHuBXiUg==",
-      "dependencies": {
-        "@types/history": "*",
-        "@types/react": "*",
-        "@types/react-router": "*"
       }
     },
     "node_modules/@types/resolve": {
@@ -12602,16 +12578,11 @@
       "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
     "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
+      "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
       "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
+        "@babel/runtime": "^7.7.6"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -16828,19 +16799,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/mini-create-react-context": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
-      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.0.0",
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/mini-css-extract-plugin": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.4.5.tgz",
@@ -19666,59 +19624,28 @@
       }
     },
     "node_modules/react-router": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
-      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
+      "integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
       "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "history": "^5.2.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
-      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
+      "integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
       "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.2.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "history": "^5.2.0",
+        "react-router": "6.2.1"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
-    },
-    "node_modules/react-router/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "node_modules/react-router/node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
-    "node_modules/react-router/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-scripts": {
       "version": "5.0.0",
@@ -20280,11 +20207,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
-    },
     "node_modules/resolve-url-loader": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-4.0.0.tgz",
@@ -20708,14 +20630,6 @@
       "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "dependencies": {
         "randombytes": "^2.1.0"
-      }
-    },
-    "node_modules/serialize-query-params": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-1.3.5.tgz",
-      "integrity": "sha512-BrLH1RqgzVxm6dco+KP9S6BodeFiUVvKwtY3GSWQlupIdblT19KCGTRkHZ2yIU6Bjy0Prjts0tYe11VpTMbAeQ==",
-      "peerDependencies": {
-        "query-string": ">=5.1.1"
       }
     },
     "node_modules/serve-index": {
@@ -21740,11 +21654,6 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
       "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
     },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "node_modules/title-case": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
@@ -22207,19 +22116,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/use-query-params": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-1.2.3.tgz",
-      "integrity": "sha512-cdG0tgbzK+FzsV6DAt2CN8Saa3WpRnze7uC4Rdh7l15epSFq7egmcB/zuREvPNwO5Yk80nUpDZpiyHsoq50d8w==",
-      "dependencies": {
-        "serialize-query-params": "^1.3.5"
-      },
-      "peerDependencies": {
-        "query-string": ">=5.1.1",
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
     "node_modules/use-sidecar": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",
@@ -22306,11 +22202,6 @@
       "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
       "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
       "dev": true
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "node_modules/value-or-promise": {
       "version": "1.0.6",
@@ -28169,11 +28060,6 @@
         "@types/node": "*"
       }
     },
-    "@types/history": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",
-      "integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA=="
-    },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -28421,25 +28307,6 @@
       "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
       "requires": {
         "@types/react": "*"
-      }
-    },
-    "@types/react-router": {
-      "version": "5.1.14",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.14.tgz",
-      "integrity": "sha512-LAJpqYUaCTMT2anZheoidiIymt8MuX286zoVFPM3DVb23aQBH0mAkFvzpd4LKqiolV8bBtZWT5Qp7hClCNDENw==",
-      "requires": {
-        "@types/history": "*",
-        "@types/react": "*"
-      }
-    },
-    "@types/react-router-dom": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.7.tgz",
-      "integrity": "sha512-D5mHD6TbdV/DNHYsnwBTv+y73ei+mMjrkGrla86HthE4/PVvL1J94Bu3qABU+COXzpL23T1EZapVVpwHuBXiUg==",
-      "requires": {
-        "@types/history": "*",
-        "@types/react": "*",
-        "@types/react-router": "*"
       }
     },
     "@types/resolve": {
@@ -32707,16 +32574,11 @@
       "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
     "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
+      "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
+        "@babel/runtime": "^7.7.6"
       }
     },
     "hoist-non-react-statics": {
@@ -35833,15 +35695,6 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
-    "mini-create-react-context": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
-      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
-      "requires": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      }
-    },
     "mini-css-extract-plugin": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.4.5.tgz",
@@ -37731,54 +37584,20 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
     "react-router": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
-      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
+      "integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "path-to-regexp": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
+        "history": "^5.2.0"
       }
     },
     "react-router-dom": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
-      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
+      "integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.2.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "history": "^5.2.0",
+        "react-router": "6.2.1"
       }
     },
     "react-scripts": {
@@ -38206,11 +38025,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
     },
-    "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
-    },
     "resolve-url-loader": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-4.0.0.tgz",
@@ -38517,12 +38331,6 @@
       "requires": {
         "randombytes": "^2.1.0"
       }
-    },
-    "serialize-query-params": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-1.3.5.tgz",
-      "integrity": "sha512-BrLH1RqgzVxm6dco+KP9S6BodeFiUVvKwtY3GSWQlupIdblT19KCGTRkHZ2yIU6Bjy0Prjts0tYe11VpTMbAeQ==",
-      "requires": {}
     },
     "serve-index": {
       "version": "1.9.1",
@@ -39303,11 +39111,6 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
       "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
     },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "title-case": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
@@ -39648,14 +39451,6 @@
         }
       }
     },
-    "use-query-params": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-1.2.3.tgz",
-      "integrity": "sha512-cdG0tgbzK+FzsV6DAt2CN8Saa3WpRnze7uC4Rdh7l15epSFq7egmcB/zuREvPNwO5Yk80nUpDZpiyHsoq50d8w==",
-      "requires": {
-        "serialize-query-params": "^1.3.5"
-      }
-    },
     "use-sidecar": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",
@@ -39728,11 +39523,6 @@
       "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
       "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
       "dev": true
-    },
-    "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "value-or-promise": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@types/node": "^17.0.5",
     "@types/react": "^16.14.6",
     "@types/react-dom": "^17.0.11",
-    "@types/react-router-dom": "^5.1.7",
     "@vulcan-fydp/schema": "github:vulcan-fydp/schema#semver:^0.0.37",
     "controller-input": "^0.3.0",
     "framer-motion": "^5.6.0",
@@ -27,11 +26,11 @@
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.22.5",
     "react-icons": "^4.3.1",
-    "react-router-dom": "^5.2.0",
+    "react-router": "^6.2.1",
+    "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",
     "subscriptions-transport-ws": "^0.9.19",
     "typescript": "^4.5.4",
-    "use-query-params": "^1.2.3",
     "web-vitals": "^2.1.2"
   },
   "scripts": {

--- a/src/app/components/JoinRoomForm/index.tsx
+++ b/src/app/components/JoinRoomForm/index.tsx
@@ -10,7 +10,7 @@ import { apolloClient } from "app/apollo";
 import React, { useCallback, useState } from "react";
 import { useEffect } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import {
   JoinRoomDocument,
   JoinRoomMutation,
@@ -44,7 +44,7 @@ export const JoinRoomForm: React.FC<{ roomId?: string }> = ({ roomId }) => {
     setFocus("nickname");
   }, [setFocus]);
 
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const onFormSubmit = useCallback<SubmitHandler<JoinRoomFormData>>(
     async ({ roomId, nickname }) => {
@@ -83,9 +83,9 @@ export const JoinRoomForm: React.FC<{ roomId?: string }> = ({ roomId }) => {
         return;
       }
 
-      history.push(`/room/${result.data.joinRoom.room.id}/stream`);
+      navigate(`/room/${result.data.joinRoom.room.id}/stream`);
     },
-    [history]
+    [navigate]
   );
 
   return (

--- a/src/app/components/Navbar/index.tsx
+++ b/src/app/components/Navbar/index.tsx
@@ -11,7 +11,7 @@ import {
   MenuItem,
   MenuDivider,
 } from "@chakra-ui/react";
-import { Link as RouterLink, NavLink, useHistory } from "react-router-dom";
+import { Link as RouterLink, NavLink, useNavigate } from "react-router-dom";
 import logo from "app/resources/vulcan-transparent.svg";
 import { useNavbarQuery } from "./navbar.backend.generated";
 
@@ -50,7 +50,7 @@ export const Navbar: React.FC<NavbarProps> = ({ children }) => {
 
 export const DefaultNavbarContent = () => {
   const { data, loading } = useNavbarQuery();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   if (loading || !data) {
     return null;
@@ -61,7 +61,7 @@ export const DefaultNavbarContent = () => {
       {!data.user ? (
         <Button
           onClick={() => {
-            history.push("/login");
+            navigate("/login");
           }}
         >
           Login

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,21 +1,17 @@
 import { ApolloProvider } from "@apollo/client";
-
-import "@fontsource/montserrat";
-
 import { ChakraProvider } from "@chakra-ui/react";
-import { BrowserRouter, Route } from "react-router-dom";
+import "@fontsource/montserrat";
 import { apolloClient } from "app/apollo";
 import { Pages } from "app/pages";
+import React from "react";
+import { BrowserRouter } from "react-router-dom";
 import { vulcanTheme } from "theme";
-import { QueryParamProvider } from "use-query-params";
 
 const VulcanGamingPlatformApp = () => (
   <ChakraProvider theme={vulcanTheme}>
     <ApolloProvider client={apolloClient}>
       <BrowserRouter>
-        <QueryParamProvider ReactRouterRoute={Route}>
-          <Pages />
-        </QueryParamProvider>
+        <Pages />
       </BrowserRouter>
     </ApolloProvider>
   </ChakraProvider>

--- a/src/app/pages/controllers/CreateControllerButton.tsx
+++ b/src/app/pages/controllers/CreateControllerButton.tsx
@@ -1,21 +1,12 @@
 import { AddIcon } from "@chakra-ui/icons";
 import { Button, ButtonProps } from "@chakra-ui/react";
-import { NavLink, useRouteMatch } from "react-router-dom";
-import {
-  CreateControllerModalStep,
-  CREATE_CONTROLLER_QUERY_PARAM,
-} from "./CreateControllerModal";
+import { useTriggerSiteModal } from "lib/site-modal";
 
 export const CreateControllerButton = (props: ButtonProps) => {
-  const { path } = useRouteMatch();
+  const triggerModal = useTriggerSiteModal("CreateController");
 
   return (
-    <Button
-      as={NavLink}
-      to={`${path}?${CREATE_CONTROLLER_QUERY_PARAM}=${CreateControllerModalStep.GAME_CONSOLE}`}
-      leftIcon={<AddIcon />}
-      {...props}
-    >
+    <Button onClick={triggerModal} leftIcon={<AddIcon />} {...props}>
       Create controller
     </Button>
   );

--- a/src/app/pages/controllers/CreateControllerModal/ControllerTypeModal.tsx
+++ b/src/app/pages/controllers/CreateControllerModal/ControllerTypeModal.tsx
@@ -9,61 +9,49 @@ import {
   ModalHeader,
   ModalOverlay,
 } from "@chakra-ui/react";
-import { useCallback } from "react";
-import { NavLink } from "react-router-dom";
-import { useQueryParam, StringParam } from "use-query-params";
-import { CreateControllerModalStep, CREATE_CONTROLLER_QUERY_PARAM } from ".";
-import { ControllersRouter } from "..";
+import { useMemo } from "react";
 import {
   ControllerType,
   CONTROLLER_TYPE_DISPLAY_ORDER,
   getControllerTypeName,
 } from "../studio/enums/controller-type";
-import { GameConsole } from "../studio/enums/game-console";
-import { GAME_CONSOLE_QUERY_PARAM } from "./GameConsoleModal";
 
 export const CONTROLLER_TYPE_QUERY_PARAM = "controller_type";
 
-export const ControllerTypeModal = () => {
-  const [createControllerModalStep, setCreateControllerModalStep] =
-    useQueryParam(CREATE_CONTROLLER_QUERY_PARAM, StringParam);
-  const [, setControllerType] = useQueryParam(
-    CONTROLLER_TYPE_QUERY_PARAM,
-    StringParam
-  );
-  const [gameConsole] = useQueryParam(GAME_CONSOLE_QUERY_PARAM, StringParam);
+interface ControllerTypeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  setControllerType: (ct: ControllerType) => void;
+}
 
-  const onClose = useCallback(() => {
-    setCreateControllerModalStep(undefined, "push");
-  }, [setCreateControllerModalStep]);
+export const ControllerTypeModal: React.FC<ControllerTypeModalProps> = ({
+  isOpen,
+  onClose,
+  setControllerType,
+}) => {
+  const controllerTypeButtons = useMemo(
+    () =>
+      CONTROLLER_TYPE_DISPLAY_ORDER.map((controllerType) => (
+        <Button
+          key={controllerType}
+          w="100%"
+          onClick={() => setControllerType(controllerType)}
+        >
+          {getControllerTypeName(controllerType)}
+        </Button>
+      )),
+    [setControllerType]
+  );
 
   return (
-    <Modal
-      isOpen={
-        createControllerModalStep === CreateControllerModalStep.CONTROLLER_TYPE
-      }
-      onClose={onClose}
-    >
+    <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>Controller Type</ModalHeader>
         <ModalCloseButton onClick={onClose} />
         <ModalBody>
           <Text>How do you want to control this controller?</Text>
-          <VStack mt="20px">
-            {CONTROLLER_TYPE_DISPLAY_ORDER.map((controllerType) => (
-              <Button
-                w="100%"
-                as={NavLink}
-                to={ControllersRouter.createUserController({
-                  gameConsole: gameConsole as GameConsole,
-                  controllerType,
-                })}
-              >
-                {getControllerTypeName(controllerType)}
-              </Button>
-            ))}
-          </VStack>
+          <VStack mt="20px">{controllerTypeButtons}</VStack>
         </ModalBody>
         <ModalFooter></ModalFooter>
       </ModalContent>

--- a/src/app/pages/controllers/CreateControllerModal/GameConsoleModal.tsx
+++ b/src/app/pages/controllers/CreateControllerModal/GameConsoleModal.tsx
@@ -9,9 +9,7 @@ import {
   ModalHeader,
   ModalOverlay,
 } from "@chakra-ui/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { useQueryParam, useQueryParams, StringParam } from "use-query-params";
-import { CreateControllerModalStep, CREATE_CONTROLLER_QUERY_PARAM } from ".";
+import { useMemo } from "react";
 import {
   GameConsole,
   GAME_CONSOLE_DISPLAY_ORDER,
@@ -20,44 +18,31 @@ import {
 
 export const GAME_CONSOLE_QUERY_PARAM = "game_console";
 
-export const GameConsoleModal: React.FC = () => {
-  const [createControllerModalStep, setCreateControllerModalStep] =
-    useQueryParam(CREATE_CONTROLLER_QUERY_PARAM, StringParam);
-  const [, setGameConsole] = useQueryParam(
-    GAME_CONSOLE_QUERY_PARAM,
-    StringParam
-  );
+interface GameConsoleModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  setGameConsole: (gc: GameConsole) => void;
+}
 
-  const onClose = useCallback(() => {
-    setCreateControllerModalStep(undefined, "push");
-  }, [setCreateControllerModalStep]);
-
-  const onGameConsoleClick = useCallback(
-    (gameConsole: GameConsole) => {
-      setCreateControllerModalStep(
-        CreateControllerModalStep.CONTROLLER_TYPE,
-        "pushIn"
-      );
-      setGameConsole(gameConsole, "pushIn");
-    },
-    [setCreateControllerModalStep, setGameConsole]
-  );
-
+export const GameConsoleModal: React.FC<GameConsoleModalProps> = ({
+  isOpen,
+  onClose,
+  setGameConsole,
+}) => {
   const gameConsoleList = useMemo(() => {
     return GAME_CONSOLE_DISPLAY_ORDER.map((gameConsole) => (
-      <Button w="100%" onClick={() => onGameConsoleClick(gameConsole)}>
+      <Button
+        w="100%"
+        onClick={() => setGameConsole(gameConsole)}
+        key={gameConsole}
+      >
         {getGameConsoleName(gameConsole)}
       </Button>
     ));
-  }, [onGameConsoleClick]);
+  }, [setGameConsole]);
 
   return (
-    <Modal
-      isOpen={
-        createControllerModalStep === CreateControllerModalStep.GAME_CONSOLE
-      }
-      onClose={onClose}
-    >
+    <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>Game Console</ModalHeader>

--- a/src/app/pages/controllers/index.tsx
+++ b/src/app/pages/controllers/index.tsx
@@ -1,5 +1,4 @@
-import { addQueryStringIfNonEmpty } from "lib/uri";
-import { Route, Switch, useRouteMatch } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 import { CreateControllerModal } from "./CreateControllerModal";
 import { ControllerLists } from "./list";
 import { DefaultControllerStudio } from "./studio/DefaultControllerStudio";
@@ -9,38 +8,20 @@ import { GameConsole } from "./studio/enums/game-console";
 import { CreateControllerStudio } from "./studio/CreateControllerStudio";
 
 export const ControllersRouter = () => {
-  const { path } = useRouteMatch();
-
   return (
     <>
       <CreateControllerModal />
-      <Switch>
+      <Routes>
+        <Route index element={<ControllerLists />} />
+        <Route path="built-in" element={<ControllerLists />} />
         <Route
-          exact
-          path={ControllersRouter.userControllerList()}
-          render={() => <ControllerLists />}
+          path="built-in/:controllerId"
+          element={<DefaultControllerStudio />}
         />
-        <Route
-          exact
-          path={ControllersRouter.builtInControllerList()}
-          render={() => <ControllerLists />}
-        />
-        <Route
-          exact
-          path={ControllersRouter.createUserController()}
-          render={() => <CreateControllerStudio />}
-        />
-        <Route
-          exact
-          path={ControllersRouter.userController()}
-          render={() => <ControllerEditStudio />}
-        />
-        <Route
-          exact
-          path={ControllersRouter.builtInController()}
-          render={() => <DefaultControllerStudio />}
-        />
-      </Switch>
+        <Route path="create" element={<CreateControllerStudio />} />
+        <Route path=":controllerId" element={<ControllerEditStudio />} />
+        <Route path="*" element={<>not found</>} />
+      </Routes>
     </>
   );
 };
@@ -83,7 +64,5 @@ ControllersRouter.createUserController = ({
     params.set("game_console", gameConsole);
   }
 
-  return `${ControllersRouter.baseRoute()}/create${addQueryStringIfNonEmpty(
-    params
-  )}`;
+  return `${ControllersRouter.baseRoute()}/create`;
 };

--- a/src/app/pages/controllers/list/index.tsx
+++ b/src/app/pages/controllers/list/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "@chakra-ui/react";
 import { HeroPage } from "app/components/HeroPage";
 import { CreateControllerButton } from "app/pages/controllers/CreateControllerButton";
-import { NavLink, useRouteMatch } from "react-router-dom";
+import { NavLink, useLocation } from "react-router-dom";
 import { DefaultControllers } from "./DefaultControllers";
 import { UserControllers } from "./UserControllers";
 
@@ -26,7 +26,7 @@ function getTabIndexFromPath(path: string) {
 }
 
 export const ControllerLists = () => {
-  const { path } = useRouteMatch();
+  const { pathname } = useLocation();
 
   return (
     <HeroPage>
@@ -35,7 +35,7 @@ export const ControllerLists = () => {
           <Text fontSize="2xl">Controllers</Text>
           <CreateControllerButton />
         </Flex>
-        <Tabs isLazy isFitted index={getTabIndexFromPath(path)} w="800px">
+        <Tabs isLazy isFitted index={getTabIndexFromPath(pathname)} w="800px">
           <TabList>
             <Tab as={NavLink} to="/controllers">
               My Controllers

--- a/src/app/pages/controllers/list/utils/getControllerShareUri.ts
+++ b/src/app/pages/controllers/list/utils/getControllerShareUri.ts
@@ -13,11 +13,7 @@ export function getControllerShareUri({
 }: Controller): string {
   return `${window.location.protocol}//${
     window.location.host
-  }${ControllersRouter.createUserController()}?${
-    nameQueryParam.name
-  }=${nameQueryParam.config.encode(name)}&${
+  }${ControllersRouter.createUserController()}?${nameQueryParam.name}=${name}&${
     buttonsQueryParam.name
-  }=${buttonsQueryParam.config.encode(buttons)}&${
-    axesQueryParam.name
-  }=${axesQueryParam.config.encode(axes)}`;
+  }=${JSON.stringify(buttons)}&${axesQueryParam.name}=${JSON.stringify(axes)}`;
 }

--- a/src/app/pages/controllers/queryParams.ts
+++ b/src/app/pages/controllers/queryParams.ts
@@ -1,41 +1,17 @@
-import { ControllerAxis, ControllerButton } from "app/backend-types";
-import { QueryParamConfig, StringParam } from "serialize-query-params";
+// @todo: Remove this, from old query param pattern
 
-function TypedJsonParam<T>(): QueryParamConfig<T[]> {
-  return {
-    encode: (buttons) => JSON.stringify(buttons),
-    decode: (buttonsJson) => {
-      if (typeof buttonsJson !== "string") {
-        return [];
-      }
-
-      return JSON.parse(buttonsJson);
-    },
-  };
-}
-
-type ControllerStudioQueryParam<D, D2 = D> = {
+type ControllerStudioQueryParam = {
   name: string;
-  config: QueryParamConfig<D, D2>;
 };
 
-export const nameQueryParam: ControllerStudioQueryParam<
-  string | null | undefined
-> = {
+export const nameQueryParam: ControllerStudioQueryParam = {
   name: "name",
-  config: StringParam,
 };
 
-export const buttonsQueryParam: ControllerStudioQueryParam<
-  (ControllerButton | null)[]
-> = {
+export const buttonsQueryParam: ControllerStudioQueryParam = {
   name: "buttons",
-  config: TypedJsonParam(),
 };
 
-export const axesQueryParam: ControllerStudioQueryParam<
-  (ControllerAxis | null)[]
-> = {
+export const axesQueryParam: ControllerStudioQueryParam = {
   name: "axes",
-  config: TypedJsonParam(),
 };

--- a/src/app/pages/controllers/studio/ControllerEditStudio.tsx
+++ b/src/app/pages/controllers/studio/ControllerEditStudio.tsx
@@ -2,7 +2,7 @@ import { ControllerAxis, ControllerButton } from "app/backend-types";
 import { ErrorPage } from "app/components/ErrorPage";
 import { LoadingPage } from "app/components/LoadingPage";
 import { useCallback, useEffect, useState } from "react";
-import { useRouteMatch } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { ControllersRouter } from "..";
 import {
   useEditControllerMutation,
@@ -20,13 +20,11 @@ import { toAxisInput, toButtonInput } from "./utils/toInput";
 const noop = () => {};
 
 export const ControllerEditStudio = () => {
-  const {
-    params: { controllerId },
-  } = useRouteMatch<{ controllerId: string }>();
+  const { controllerId } = useParams<{ controllerId: string }>();
 
   const { data, loading, error } = useEditControllerStudioQuery({
     variables: {
-      controllerId,
+      controllerId: controllerId!,
     },
   });
 
@@ -89,7 +87,7 @@ export const ControllerEditStudio = () => {
   const onSave = useCallback(async () => {
     await editControllerMutation({
       variables: {
-        controllerId,
+        controllerId: controllerId!,
         name,
         buttons: buttons.map(toButtonInput),
         axes: axes.map(toAxisInput),

--- a/src/app/pages/controllers/studio/DefaultControllerStudio.tsx
+++ b/src/app/pages/controllers/studio/DefaultControllerStudio.tsx
@@ -1,9 +1,4 @@
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-} from "@chakra-ui/breadcrumb";
-import { Link, useRouteMatch } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useDefaultControllerStudioQuery } from "./defaultControllerStudio.backend.generated";
 import { ControllerType } from "./enums/controller-type";
 import { GameConsole } from "./enums/game-console";
@@ -12,13 +7,11 @@ import { ControllerStudio } from "./Studio";
 const noop = () => {};
 
 export const DefaultControllerStudio = () => {
-  const {
-    params: { controllerId },
-  } = useRouteMatch<{ controllerId: string }>();
+  const { controllerId } = useParams<{ controllerId: string }>();
 
   const { data, loading, error } = useDefaultControllerStudioQuery({
     variables: {
-      controllerId,
+      controllerId: controllerId!,
     },
   });
 

--- a/src/app/pages/docs/components/DocPage.tsx
+++ b/src/app/pages/docs/components/DocPage.tsx
@@ -8,8 +8,6 @@ import {
   BreadcrumbItem,
   BreadcrumbLink,
 } from "@chakra-ui/react";
-import { useEffect, useLayoutEffect } from "react";
-import { useRouteMatch } from "react-router";
 import { Link } from "react-router-dom";
 import { DocsRoutes } from "..";
 import { DocContentContextProvider } from "./doc-content";

--- a/src/app/pages/docs/components/doc-content.tsx
+++ b/src/app/pages/docs/components/doc-content.tsx
@@ -2,12 +2,10 @@ import React, {
   useCallback,
   useContext,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
-import { useRouteMatch, useLocation } from "react-router-dom";
 import { idify } from "./idify";
 
 interface DocContentContextType {

--- a/src/app/pages/docs/index.tsx
+++ b/src/app/pages/docs/index.tsx
@@ -1,12 +1,11 @@
-import { Route, Switch } from "react-router";
+import { Route, Routes } from "react-router-dom";
 import { Docs } from "./Docs";
 
 export const DocsRouter = () => {
   return (
-    <Switch>
-      <Route exact path={DocsRoutes.base()} render={Docs} />
-      <Route path={DocsRoutes.vulcast()} render={() => null} />
-    </Switch>
+    <Routes>
+      <Route index element={<Docs />} />
+    </Routes>
   );
 };
 

--- a/src/app/pages/index.tsx
+++ b/src/app/pages/index.tsx
@@ -1,23 +1,16 @@
-import { Route, Switch } from "react-router";
+import { Routes, Route } from "react-router-dom";
 import { Home } from "./Home";
 import { LoginRouter } from "app/pages/login";
 import { RoomRouter } from "./room";
 import { ControllersRouter } from "./controllers";
-import { DocsRouter, DocsRoutes } from "./docs";
 import { AccountPage } from "./account";
 
 export const Pages = () => (
-  <Switch>
-    {/* These routes are semi-placeholder and subject to change */}
-    <Route exact path="/" render={() => <Home />} />
-
-    <Route path="/room" render={() => <RoomRouter />} />
-    <Route path="/login" render={() => <LoginRouter />} />
-    <Route path="/controllers" render={() => <ControllersRouter />} />
-    <Route exact path="/account" render={() => <AccountPage />} />
-
-    <Route path={DocsRoutes.base()} render={() => <DocsRouter />} />
-
-    <Route render={() => null} />
-  </Switch>
+  <Routes>
+    <Route path="/" element={<Home />} />
+    <Route path="room/*" element={<RoomRouter />} />
+    <Route path="login" element={<LoginRouter />} />
+    <Route path="controllers/*" element={<ControllersRouter />} />
+    <Route path="account" element={<AccountPage />} />
+  </Routes>
 );

--- a/src/app/pages/login/Login/index.tsx
+++ b/src/app/pages/login/Login/index.tsx
@@ -12,7 +12,7 @@ import {
 import { HeroPage } from "app/components/HeroPage";
 import React, { useCallback, useState } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
-import { Link as RouterLink, useHistory } from "react-router-dom";
+import { Link as RouterLink, useNavigate } from "react-router-dom";
 import { useLogInMutation } from "./logIn.backend.generated";
 
 interface LoginForm {
@@ -27,7 +27,7 @@ export const LoginPage = () => {
     setError,
     formState: { errors, isSubmitting },
   } = useForm<LoginForm>();
-  const history = useHistory();
+  const navigate = useNavigate();
   const apolloClient = useApolloClient();
 
   const [responseError, setResponseError] = useState<string>();
@@ -51,14 +51,14 @@ export const LoginPage = () => {
       switch (logInResult.logInAsUser.__typename) {
         case "User":
           await apolloClient.resetStore();
-          history.push("/room");
+          navigate("/room");
           break;
         case "AuthenticationError":
           setResponseError(logInResult.logInAsUser.message);
           break;
       }
     },
-    [logIn, history, setResponseError, apolloClient]
+    [logIn, navigate, setResponseError, apolloClient]
   );
 
   return (

--- a/src/app/pages/login/index.tsx
+++ b/src/app/pages/login/index.tsx
@@ -1,16 +1,13 @@
-import { Route, Switch } from "react-router";
-import { useRouteMatch } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 import { LoginPage } from "./Login";
 
 export const LoginRouter = () => {
-  const { path } = useRouteMatch();
-
   return (
-    <Switch>
-      <Route exact path={path} render={() => <LoginPage />} />
-      <Route exact path={`${path}/forgot-password`} render={() => null} />
-      <Route exact path={`${path}/google`} render={() => null} />
-      <Route exact path={`${path}/facebook`} render={() => null} />
-    </Switch>
+    <Routes>
+      <Route index element={<LoginPage />} />
+      <Route path="forgot-password" element={null} />
+      <Route path="google" element={null} />
+      <Route path="facebook" element={null} />
+    </Routes>
   );
 };

--- a/src/app/pages/room/JoinOrHostRoom/CreateRoomForm.tsx
+++ b/src/app/pages/room/JoinOrHostRoom/CreateRoomForm.tsx
@@ -1,13 +1,13 @@
 import { Button, Flex } from "@chakra-ui/react";
 import React, { useCallback } from "react";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useCreateRoomMutation } from "./createRoom.backend.generated";
 
 export const CreateRoomForm: React.FC<{ vulcastId: string }> = ({
   vulcastId,
 }) => {
   const [createRoomMutation, { loading }] = useCreateRoomMutation();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const onCreateRoomClick = useCallback(async () => {
     const result = await createRoomMutation({
@@ -30,10 +30,10 @@ export const CreateRoomForm: React.FC<{ vulcastId: string }> = ({
       case "VulcastNotFoundError":
         return;
       case "Room":
-        history.push(`/room/${result.data.createRoom.id}/players`);
+        navigate(`/room/${result.data.createRoom.id}/players`);
         return;
     }
-  }, [createRoomMutation, vulcastId, history]);
+  }, [createRoomMutation, vulcastId, navigate]);
 
   return (
     <Flex>

--- a/src/app/pages/room/JoinOrHostRoom/index.tsx
+++ b/src/app/pages/room/JoinOrHostRoom/index.tsx
@@ -1,15 +1,14 @@
 import { Center, Flex, HStack, Text } from "@chakra-ui/react";
 import { HeroPage } from "app/components/HeroPage";
 import React from "react";
-import { useRouteMatch } from "react-router";
-import { Redirect } from "react-router-dom";
+import { Navigate, useParams } from "react-router-dom";
 import { CreateRoomForm } from "./CreateRoomForm";
 import { JoinRoomForm } from "app/components/JoinRoomForm";
 import { RegisterVulcastForm } from "./RegisterVulcastForm";
 import { useJoinOrHostRoomQuery } from "./joinOrHostRoom.backend.generated";
 
 export const JoinOrHostRoom: React.FC = () => {
-  const { params } = useRouteMatch<{ roomId?: string }>();
+  const { roomId } = useParams<{ roomId?: string }>();
 
   const { data, loading } = useJoinOrHostRoomQuery();
 
@@ -20,15 +19,15 @@ export const JoinOrHostRoom: React.FC = () => {
   if (data.roomSession) {
     let path = `/room/${data.roomSession.room.id}/stream`;
 
-    if (params.roomId !== data.roomSession.room.id) {
-      path += `?join-another-room=${params.roomId}`;
+    if (roomId !== data.roomSession.room.id) {
+      path += `?join-another-room=${roomId}`;
     }
 
-    return <Redirect to={path} />;
+    return <Navigate replace to={path} />;
   }
 
-  if (!data.user || params.roomId !== undefined) {
-    return <JoinRoom roomId={params.roomId} />;
+  if (!data.user || roomId !== undefined) {
+    return <JoinRoom roomId={roomId} />;
   }
 
   if (data.user.vulcasts.length === 0) {
@@ -36,10 +35,7 @@ export const JoinOrHostRoom: React.FC = () => {
   }
 
   return (
-    <JoinAndHostRoom
-      vulcastId={data.user.vulcasts[0].id}
-      roomId={params.roomId}
-    />
+    <JoinAndHostRoom vulcastId={data.user.vulcasts[0].id} roomId={roomId} />
   );
 };
 

--- a/src/app/pages/room/Room/JoinAnotherRoomModal.tsx
+++ b/src/app/pages/room/Room/JoinAnotherRoomModal.tsx
@@ -7,8 +7,8 @@ import {
   AlertDialogOverlay,
   Button,
 } from "@chakra-ui/react";
+import { useStringSearchParam } from "lib/useSearchParam";
 import { useRef } from "react";
-import { StringParam, useQueryParam } from "use-query-params";
 
 interface JoinAnotherRoomModalProps {
   onLeave: (otherRoomCode?: string) => void;
@@ -20,9 +20,9 @@ export const JoinAnotherRoomModal: React.FC<JoinAnotherRoomModalProps> = ({
   const stayButtonRef = useRef<HTMLButtonElement>(null);
   const leaveButtonRef = useRef<HTMLButtonElement>(null);
 
-  const [otherRoom, setOtherRoom] = useQueryParam(
+  const [otherRoom, setOtherRoom] = useStringSearchParam(
     "join-another-room",
-    StringParam
+    false
   );
 
   return (

--- a/src/app/pages/room/Room/StreamTab.tsx
+++ b/src/app/pages/room/Room/StreamTab.tsx
@@ -11,7 +11,7 @@ import { Device } from "mediasoup-client";
 import { DataProducer } from "mediasoup-client/lib/DataProducer";
 import { DtlsParameters, Transport } from "mediasoup-client/lib/Transport";
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { useRouteMatch } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { SubscriptionClient } from "subscriptions-transport-ws";
 import { useRoomSessionQuery } from "./roomSession.backend.generated";
 import {
@@ -109,7 +109,7 @@ export const StreamTab: React.FC = () => {
   const receiveMediaStreamRef = useRef<MediaStream>();
   const dataProducerRef = useRef<DataProducer>();
 
-  const { params } = useRouteMatch<{ roomId?: string }>();
+  const { roomId } = useParams<{ roomId?: string }>();
 
   useEffect(() => {
     document.querySelectorAll("video").forEach((v) => (v.volume = 0.1));
@@ -263,7 +263,7 @@ export const StreamTab: React.FC = () => {
     return () => {
       clientSub?.close();
     };
-  }, [params.roomId]);
+  }, [roomId]);
 
   const emitData = useCallback(
     (data: ArrayBuffer) => {

--- a/src/app/pages/room/index.tsx
+++ b/src/app/pages/room/index.tsx
@@ -1,16 +1,15 @@
-import { Route, Switch } from "react-router";
-import { useRouteMatch } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 import { Dashboard } from "app/pages/room/Room";
 import { JoinOrHostRoom } from "./JoinOrHostRoom";
 
 export const RoomRouter = () => {
-  const { path } = useRouteMatch();
-
   return (
-    <Switch>
-      <Route exact path={path} render={() => <JoinOrHostRoom />} />
-      <Route exact path={`${path}/:roomId`} render={() => <JoinOrHostRoom />} />
-      <Route path={`${path}/:roomId`} render={() => <Dashboard />} />
-    </Switch>
+    <Routes>
+      <Route index element={<JoinOrHostRoom />} />
+      <Route path=":roomId">
+        <Route index element={<JoinOrHostRoom />} />
+        <Route path="*" element={() => <Dashboard />} />
+      </Route>
+    </Routes>
   );
 };

--- a/src/lib/site-modal.ts
+++ b/src/lib/site-modal.ts
@@ -1,0 +1,27 @@
+import { useCallback } from "react";
+import { useStringSearchParam } from "./useSearchParam";
+
+const TRIGGER_MODAL_PARAM = "trigger_modal";
+
+export function useTriggerSiteModal(modalName: string) {
+  const [, setModalTriggered] = useStringSearchParam(TRIGGER_MODAL_PARAM);
+
+  const triggerSiteModal = useCallback(() => {
+    setModalTriggered(modalName);
+  }, [modalName, setModalTriggered]);
+
+  return triggerSiteModal;
+}
+
+export function useIsSiteModalTriggered(
+  modalName: string
+): [boolean, () => void] {
+  const [modalTriggered, setModalTriggered] =
+    useStringSearchParam(TRIGGER_MODAL_PARAM);
+
+  const clearModalTriggered = useCallback(() => {
+    setModalTriggered(undefined);
+  }, [setModalTriggered]);
+
+  return [modalTriggered === modalName, clearModalTriggered];
+}

--- a/src/lib/useSearchParam.ts
+++ b/src/lib/useSearchParam.ts
@@ -1,0 +1,65 @@
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+type EncodeFunction<T> = (value: T) => string;
+type DecodeFunction<T> = (value: string) => T;
+
+export function useSearchParam<T>(
+  param: string,
+  encode: EncodeFunction<T>,
+  decode: DecodeFunction<T>,
+  replace = true
+): [T | undefined, (v: T | undefined) => void] {
+  const [params, setParams] = useSearchParams();
+
+  const encodedValue = useMemo(() => {
+    return params.get(param);
+  }, [params, param]);
+
+  const decodedValue = useMemo(() => {
+    if (encodedValue === null) {
+      return undefined;
+    }
+    try {
+      return decode(encodedValue);
+    } catch {
+      return undefined;
+    }
+  }, [decode, encodedValue]);
+
+  const setParam = useCallback(
+    (newValue: T | undefined) => {
+      const newParams = new URLSearchParams(params.toString());
+      if (newValue === undefined) {
+        newParams.delete(param);
+      } else {
+        try {
+          newParams.set(param, encode(newValue));
+        } catch {}
+      }
+      setParams(newParams, { replace });
+    },
+    [encode, params, param, setParams, replace]
+  );
+
+  const returnValue: [T | undefined, (v: T | undefined) => void] =
+    useMemo(() => {
+      return [decodedValue, setParam];
+    }, [decodedValue, setParam]);
+
+  return returnValue;
+}
+
+const encodeString: EncodeFunction<string> = (value) => value;
+const decodeString: DecodeFunction<string> = (value) => value;
+
+export function useStringSearchParam(param: string, replace?: boolean) {
+  return useSearchParam(param, encodeString, decodeString, replace);
+}
+
+const encodeJson = <T>(value: T) => JSON.stringify(value);
+const decodeJson = <T>(value: string) => JSON.parse(value) as T;
+
+export function useJsonSearchParam<T>(param: string, replace?: boolean) {
+  return useSearchParam<T>(param, encodeJson, decodeJson, replace);
+}

--- a/src/static/pages/index.tsx
+++ b/src/static/pages/index.tsx
@@ -1,12 +1,12 @@
-import { BrowserRouter, Route, Switch } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { DocsPage } from "./docs";
 import { HomePage } from "./home";
 
 export const Router = () => (
   <BrowserRouter>
-    <Switch>
-      <Route exact path="/" component={HomePage} />
-      <Route path="/docs" component={DocsPage} />
-    </Switch>
+    <Routes>
+      <Route index element={<HomePage />} />
+      <Route path="docs/*" element={<DocsPage />} />
+    </Routes>
   </BrowserRouter>
 );


### PR DESCRIPTION
1. Upgrade react-router and react-router-dom to v6
2. Migrate `Switch` to `Routes`
3. Rewrite how we handle query param state because the library we were using is not compatible with v6 (I did not know this beforehand 😢)
4. Rewrite one modal to use state instead of query params because it doesn't make a lot of sense to use the url for that state
5. Create hooks for using site-wide modals (this will be helpful for the create controller modal if we also want to add a `Create Controller` button from within a room). I didn't finish implementing the pattern but some of the infrastructure for it is there