### PR TITLE
Refactor navbar to be a reusable component across sites + banner

### DIFF
--- a/src/app/components/HeroPage/index.tsx
+++ b/src/app/components/HeroPage/index.tsx
@@ -1,10 +1,26 @@
 import React from "react";
-import { Navbar } from "app/components/Navbar";
+import { DefaultNavbar } from "app/components/Navbar";
 import { Flex, Box } from "@chakra-ui/layout";
+import { useNavbarHeight } from "lib/Navbar";
 
 interface HeroProps {
   isDashboard?: boolean;
 }
+
+const HeroPageContent: React.FC = ({ children }) => {
+  const navbarHeight = useNavbarHeight();
+
+  return (
+    <Flex
+      pt={`${navbarHeight + 30}px`}
+      minHeight="100vh"
+      flexDir="column"
+      align="center"
+    >
+      {children}
+    </Flex>
+  );
+};
 
 export const HeroPage: React.FC<HeroProps> = ({ children, isDashboard }) => {
   return (
@@ -15,10 +31,9 @@ export const HeroPage: React.FC<HeroProps> = ({ children, isDashboard }) => {
           : "linear-gradient(132.85deg, #30292F 0%, #413F54 100%);"
       }
     >
-      <Navbar />
-      <Flex pt="80px" minHeight="100vh" flexDir="column" align="center">
-        {children}
-      </Flex>
+      <DefaultNavbar>
+        <HeroPageContent>{children}</HeroPageContent>
+      </DefaultNavbar>
     </Box>
   );
 };

--- a/src/app/components/Navbar/index.tsx
+++ b/src/app/components/Navbar/index.tsx
@@ -1,90 +1,84 @@
 import {
-  Flex,
-  Link,
-  Center,
-  Box,
-  Image,
   Button,
+  Link,
   Menu,
   MenuButton,
-  MenuList,
-  MenuItem,
   MenuDivider,
+  MenuItem,
+  MenuList,
 } from "@chakra-ui/react";
-import { Link as RouterLink, NavLink, useNavigate } from "react-router-dom";
-import logo from "app/resources/vulcan-transparent.svg";
+import { Navbar } from "lib/Navbar";
+import {
+  Link as RouterLink,
+  NavLink,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
 import { useNavbarQuery } from "./navbar.backend.generated";
 
-interface NavbarProps {
-  children?: null;
-}
-
-export const Navbar: React.FC<NavbarProps> = ({ children }) => {
-  return (
-    <Center
-      bg="black"
-      position="fixed"
-      top="0"
-      left="0"
-      right="0"
-      bottom="calc(100% - 50px)"
-      zIndex="999"
-    >
-      <Flex
-        justifyContent="space-between"
-        alignItems="center"
-        w="100%"
-        maxWidth="1040px"
-        padding="0 20px"
-      >
-        <Box>
-          <Link as={RouterLink} to="/">
-            <Image src={logo} />
-          </Link>
-        </Box>
-        {children !== undefined ? children : <DefaultNavbarContent />}
-      </Flex>
-    </Center>
-  );
-};
-
-export const DefaultNavbarContent = () => {
+export const DefaultNavbar: React.FC = ({ children }) => {
   const { data, loading } = useNavbarQuery();
   const navigate = useNavigate();
+  const location = useLocation();
 
   if (loading || !data) {
-    return null;
+    return <Navbar>{children}</Navbar>;
   }
 
   return (
-    <>
-      {!data.user ? (
-        <Button
-          onClick={() => {
-            navigate("/login");
-          }}
-        >
-          Login
-        </Button>
-      ) : null}
-      {data.user ? (
-        <Menu placement="bottom-end">
-          <MenuButton as={Button}>Profile</MenuButton>
-          <MenuList>
-            <MenuItem as={NavLink} to="/account">
-              Account
-            </MenuItem>
-            <MenuItem>
-              {data.user.vulcasts.length > 0 ? "Vulcasts" : "Link Vulcast"}
-            </MenuItem>
-            <MenuItem as={NavLink} to="/controllers">
-              Controllers
-            </MenuItem>
-            <MenuDivider />
-            <MenuItem>Log Out</MenuItem>
-          </MenuList>
-        </Menu>
-      ) : null}
-    </>
+    <Navbar
+      bannerContent={
+        !location.pathname.startsWith("/room") && data.roomSession ? (
+          <Link
+            as={RouterLink}
+            to={`/room/${data.roomSession.room.id}/stream`}
+            backgroundColor="yellow.300"
+            color="black"
+            flex="1 1 auto"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            _hover={{
+              backgroundColor: "yellow.400",
+            }}
+          >
+            Return to room 🎮
+          </Link>
+        ) : null
+      }
+      rightContent={
+        <>
+          {!data.user ? (
+            <Button
+              onClick={() => {
+                navigate("/login");
+              }}
+            >
+              Login
+            </Button>
+          ) : null}
+          {data.user ? (
+            <Menu placement="bottom-end">
+              <MenuButton as={Button}>Profile</MenuButton>
+              <MenuList>
+                <MenuItem as={NavLink} to="/account">
+                  Account
+                </MenuItem>
+                <MenuItem>
+                  {data.user.vulcasts.length > 0 ? "Vulcasts" : "Link Vulcast"}
+                </MenuItem>
+                <MenuItem as={NavLink} to="/controllers">
+                  Controllers
+                </MenuItem>
+                <MenuDivider />
+                <MenuItem>Log Out</MenuItem>
+              </MenuList>
+            </Menu>
+          ) : null}
+        </>
+      }
+    >
+      {children}
+    </Navbar>
   );
 };

--- a/src/app/components/Navbar/navbar.backend.gql
+++ b/src/app/components/Navbar/navbar.backend.gql
@@ -7,4 +7,10 @@ query navbar {
       id
     }
   }
+  roomSession {
+    id
+    room {
+      id
+    }
+  }
 }

--- a/src/app/pages/Home/index.tsx
+++ b/src/app/pages/Home/index.tsx
@@ -1,4 +1,4 @@
-import { Navbar } from "app/components/Navbar";
+import { DefaultNavbar } from "app/components/Navbar";
 import { Box, Stack, Heading, Text } from "@chakra-ui/react";
 import { JoinRoomForm } from "app/components/JoinRoomForm";
 
@@ -10,23 +10,24 @@ export const Home = () => {
       padding="0 20px 100px 20px"
       minHeight="100vh"
     >
-      <Navbar />
-      <Stack spacing="40px" alignItems="center" paddingTop="100px" mb="40px">
-        <Text variant="heading1" w="675px">
-          Play with your friends
-          <Text as="span" color="#9F7AEA">
-            {" anywhere."}
+      <DefaultNavbar>
+        <Stack spacing="40px" alignItems="center" paddingTop="100px" mb="40px">
+          <Text variant="heading1" w="675px">
+            Play with your friends
+            <Text as="span" color="#9F7AEA">
+              {" anywhere."}
+            </Text>
           </Text>
-        </Text>
-        <Heading size="md" textAlign="center">
-          Vulcan makes it simple to play the
-          <Text as="span" color="#FFF275">
-            {" Nintendo Switch "}
-          </Text>
-          with your friends.
-        </Heading>
-      </Stack>
-      <JoinRoomForm />
+          <Heading size="md" textAlign="center">
+            Vulcan makes it simple to play the
+            <Text as="span" color="#FFF275">
+              {" Nintendo Switch "}
+            </Text>
+            with your friends.
+          </Heading>
+        </Stack>
+        <JoinRoomForm />
+      </DefaultNavbar>
     </Box>
   );
 };

--- a/src/lib/Navbar.tsx
+++ b/src/lib/Navbar.tsx
@@ -1,0 +1,70 @@
+import { Box, Center, Flex, Image, Link } from "@chakra-ui/react";
+// @todo: This shouldn't be in app
+import logo from "app/resources/vulcan-transparent.svg";
+import { Link as RouterLink } from "react-router-dom";
+import { createContext, useContext } from "react";
+
+const NavbarContext = createContext(0);
+
+export const useNavbarHeight = () => {
+  return useContext(NavbarContext);
+};
+
+interface NavbarProps {
+  children?: React.ReactNode;
+  rightContent?: React.ReactNode;
+  bannerContent?: React.ReactNode;
+}
+
+export const Navbar: React.FC<NavbarProps> = ({
+  rightContent,
+  bannerContent,
+  children,
+}) => {
+  const bannerHeight = bannerContent ? 30 : 0;
+  const navbarHeight = 50;
+  const totalHeight = navbarHeight + bannerHeight;
+
+  return (
+    <NavbarContext.Provider value={totalHeight}>
+      <Center
+        bg="black"
+        position="fixed"
+        top="0"
+        left="0"
+        right="0"
+        bottom={`calc(100% - ${totalHeight}px)`}
+        zIndex="999"
+        flexDir="column"
+      >
+        {bannerContent ? (
+          <Flex
+            alignItems="stretch"
+            justifyContent="stretch"
+            height="30px"
+            width="100%"
+          >
+            {bannerContent}
+          </Flex>
+        ) : null}
+        <Flex
+          justifyContent="space-between"
+          alignItems="center"
+          w="100%"
+          maxWidth="1040px"
+          padding="0 20px"
+          height={`${navbarHeight}px`}
+        >
+          <Box>
+            <Link as={RouterLink} to="/">
+              <Image src={logo} />
+            </Link>
+          </Box>
+          {rightContent !== undefined ? rightContent : null}
+        </Flex>
+      </Center>
+
+      {children}
+    </NavbarContext.Provider>
+  );
+};


### PR DESCRIPTION
- Refactor `DefaultNavbar` to be an instance of `Navbar`
- Make `Navbar` a composible component to add a `useNavbarHeight` hook
- Added the ability to add a banner to the navbar
  - Added return to room banner for when on a non-`room` page while in a room