### PR TITLE
Add gamepad context

### DIFF
--- a/src/app/components/GamepadToasts.tsx
+++ b/src/app/components/GamepadToasts.tsx
@@ -1,0 +1,36 @@
+import { useToast } from "@chakra-ui/react";
+import { useGamepadUpdateTrigger } from "app/contexts/gamepad";
+import { getGamepadsEnabled, NUM_GAMEPADS } from "lib/getGamepadsEnabled";
+import { useEffect, useRef } from "react";
+
+export const GamepadToasts: React.FC = () => {
+  const showToast = useToast();
+
+  const prevGamepadsEnabledRef = useRef(getGamepadsEnabled());
+
+  const gamepadUpdateTrigger = useGamepadUpdateTrigger();
+
+  useEffect(() => {
+    const gamepadsEnabled = getGamepadsEnabled();
+
+    for (let i = 0; i < NUM_GAMEPADS; i++) {
+      if (gamepadsEnabled[i] && !prevGamepadsEnabledRef.current[i]) {
+        showToast({
+          title: `Gamepad ${i + 1} connected`,
+          status: "info",
+          position: "top",
+        });
+      } else if (!gamepadsEnabled[i] && prevGamepadsEnabledRef.current[i]) {
+        showToast({
+          title: `Gamepad ${i + 1} disconnected`,
+          status: "warning",
+          position: "top",
+        });
+      }
+    }
+
+    prevGamepadsEnabledRef.current = gamepadsEnabled;
+  }, [gamepadUpdateTrigger, prevGamepadsEnabledRef, showToast]);
+
+  return null;
+};

--- a/src/app/contexts/gamepad.tsx
+++ b/src/app/contexts/gamepad.tsx
@@ -1,0 +1,66 @@
+import { getGamepadsEnabled, NUM_GAMEPADS } from "lib/getGamepadsEnabled";
+import React, { useContext, useEffect, useState } from "react";
+
+const GamepadContext = React.createContext(0);
+
+export const GamepadProvider = React.memo(({ children }) => {
+  const [gamepadsState, setGamepadsState] = useState({
+    counter: 1,
+    gamepadsEnabled: getGamepadsEnabled(),
+  });
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const gamepads = navigator.getGamepads();
+
+      setGamepadsState((prevGamepadsState) => {
+        const { counter, gamepadsEnabled: prevGamepadsEnabled } =
+          prevGamepadsState;
+
+        for (let i = 0; i < NUM_GAMEPADS; i++) {
+          if (!!gamepads[i] !== prevGamepadsEnabled[i]) {
+            return {
+              counter: counter + 1,
+              gamepadsEnabled: getGamepadsEnabled(),
+            };
+          }
+        }
+
+        return prevGamepadsState;
+      });
+    }, 200);
+
+    return () => clearTimeout(interval);
+  }, [setGamepadsState]);
+
+  return (
+    <GamepadContext.Provider value={gamepadsState.counter}>
+      {children}
+    </GamepadContext.Provider>
+  );
+});
+
+/**
+ * A hook that should be used to determine if gamepads have been connected
+ * or disconnected this update.
+ *
+ * The return type should be treated as opaque and should only be used
+ * in the dependency array of hooks to cause them to update.
+ *
+ * ```
+ * const gamepadUpdateTrigger = useGamepadUpdateTrigger();
+ *
+ * useEffect(() => {
+ *   console.log("Some gamepad state changed! We don't know what though.");
+ * }, [gamepadUpdateTrigger]);
+ * ```
+ *
+ * Motivation:
+ * I've (@MJez29) seen before where wrappers on browser apis get out of sync with
+ * the apis themselves and can cause unexpected states. To avoid this I'm trying
+ * out a "trigger" pattern where the global state detects when there are changes
+ * to `navigator.getGamepads()` and changes the value of the trigger variable. It
+ * is up to consumers to pull the state directly from the browser rather than being
+ * passed potentially stale state by the hook.
+ */
+export const useGamepadUpdateTrigger = () => useContext(GamepadContext);

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -6,13 +6,18 @@ import { Pages } from "app/pages";
 import React from "react";
 import { BrowserRouter } from "react-router-dom";
 import { vulcanTheme } from "theme";
+import { GamepadToasts } from "./components/GamepadToasts";
+import { GamepadProvider } from "./contexts/gamepad";
 
 const VulcanGamingPlatformApp = () => (
   <ChakraProvider theme={vulcanTheme}>
     <ApolloProvider client={apolloClient}>
-      <BrowserRouter>
-        <Pages />
-      </BrowserRouter>
+      <GamepadProvider>
+        <GamepadToasts />
+        <BrowserRouter>
+          <Pages />
+        </BrowserRouter>
+      </GamepadProvider>
     </ApolloProvider>
   </ChakraProvider>
 );

--- a/src/lib/getGamepadsEnabled.ts
+++ b/src/lib/getGamepadsEnabled.ts
@@ -1,0 +1,13 @@
+// Firefox has a dynamically sized array so instead we always use a
+// fixed size for consistent behaviour across browsers.
+export const NUM_GAMEPADS = 4;
+
+export function getGamepadsEnabled(): boolean[] {
+  const gamepadsEnabled = [];
+
+  for (let i = 0; i < NUM_GAMEPADS; i++) {
+    gamepadsEnabled[i] = !!navigator.getGamepads()[i];
+  }
+
+  return gamepadsEnabled;
+}


### PR DESCRIPTION
- Adds the `useGamepadUpdateTrigger` hook that should be used whenever reactive gamepads state is needed
- Provides sample use of hook with GamepadToasts component

![image](https://user-images.githubusercontent.com/20645805/157371824-14b0742a-5a9e-4912-b482-72ad6889d010.png)
